### PR TITLE
Add Go implementation

### DIFF
--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -1,0 +1,3 @@
+
+# v1.0.0
+- Initial release

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,26 @@
+# flexver
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/unascribed/FlexVer/go.svg)](https://pkg.go.dev/github.com/unascribed/FlexVer/go/flexver)
+
+A Go implementation of FlexVer.
+
+## Getting it
+
+Use `go get` to download the library:
+
+```bash
+go get -u github.com/unascribed/FlexVer/go/flexver
+```
+
+Then import the module in your Go code with `import "github.com/unascribed/FlexVer/go/flexver"`
+
+## Usage
+
+See the [documentation at pkg.go.dev](https://pkg.go.dev/github.com/unascribed/FlexVer/go/flexver)! In most cases, you'll want to use the `Compare` function to compare two versions:
+
+```go
+fmt.Println(flexver.Compare("1.0.1", "1.0.0"))
+// Output: 1
+```
+
+For various [sorting functions](https://pkg.go.dev/sort) provided by the standard library (and [generic versions from `golang.org/x/exp/slices`](https://pkg.go.dev/golang.org/x/exp/slices#SortFunc)) a `Less` function is provided, complying with the contract those functions require.

--- a/go/flexver/.gitignore
+++ b/go/flexver/.gitignore
@@ -1,0 +1,2 @@
+# GoLand
+.idea/

--- a/go/flexver/go.mod
+++ b/go/flexver/go.mod
@@ -1,0 +1,3 @@
+module github.com/unascribed/FlexVer/go/flexver
+
+go 1.19

--- a/go/flexver/main.go
+++ b/go/flexver/main.go
@@ -39,6 +39,16 @@ type component struct {
 	value []rune
 }
 
+func signum(v int) int32 {
+	if v > 0 {
+		return 1
+	} else if v == 0 {
+		return 0
+	} else {
+		return -1
+	}
+}
+
 // compare determines if this component is less than, equal to or greater than the given component.
 // A negative, zero or positive integer respectively indicates this result.
 func (compA component) compare(compB component) int32 {
@@ -54,8 +64,8 @@ func (compA component) compare(compB component) int32 {
 		}
 		aLen := len(compA.value) - i
 		if aLen != len(compB.value)-j {
-			// Lengths differ; compare by length
-			return int32(aLen - (len(compB.value) - j))
+			// Lengths differ; compare by length - signum used to prevent overflow
+			return signum(aLen - (len(compB.value) - j))
 		}
 		// Compare by digits
 		for ; i < aLen; i, j = i+1, j+1 {
@@ -90,8 +100,8 @@ func (compA component) compare(compB component) int32 {
 			return a - b
 		}
 	}
-	// Compare by length
-	return int32(len(compA.value) - len(compB.value))
+	// Compare by length - signum used to prevent overflow
+	return signum(len(compA.value) - len(compB.value))
 }
 
 // ErrInvalidUTF8 is returned from the *Error functions when a passed string is invalid UTF-8.

--- a/go/flexver/main.go
+++ b/go/flexver/main.go
@@ -1,0 +1,264 @@
+/*
+ * To the extent possible under law, the author has dedicated all copyright
+ * and related and neighboring rights to this software to the public domain
+ * worldwide. This software is distributed without any warranty.
+ *
+ * See <http://creativecommons.org/publicdomain/zero/1.0/>
+ */
+
+// Package flexver implements FlexVer, a SemVer-compatible intuitive comparator for free-form versioning strings as
+// seen in the wild. It's designed to sort versions like people do, rather than attempting to force
+// conformance to a rigid and limited standard. As such, it imposes no restrictions. Comparing two
+// versions with differing formats will likely produce nonsensical results (garbage in, garbage out),
+// but best effort is made to correct for basic structural changes, and versions of differing length
+// will be parsed in a logical fashion.
+//
+// See the specification at https://github.com/unascribed/FlexVer/blob/trunk/SPEC.md
+package flexver
+
+import (
+	"errors"
+	"sort"
+	"unicode/utf8"
+)
+
+type componentType uint8
+
+const (
+	componentTypeTextual componentType = iota
+	componentTypeNumeric
+	componentTypePreRelease
+	// componentTypeAppendix (unused; appendix components removed in decompose)
+	componentTypeNull
+)
+
+var nullComponent = component{t: componentTypeNull, value: nil}
+
+type component struct {
+	t     componentType
+	value []rune
+}
+
+// compare determines if this component is less than, equal to or greater than the given component.
+// A negative, zero or positive integer respectively indicates this result.
+func (compA component) compare(compB component) int32 {
+	// If both components are numeric, compare numerically (codepoint-wise)
+	if compA.t == componentTypeNumeric && compB.t == componentTypeNumeric {
+		var i, j int
+		// Ignore leading zeroes
+		for i < len(compA.value) && compA.value[i] == '0' {
+			i++
+		}
+		for j < len(compB.value) && compB.value[j] == '0' {
+			j++
+		}
+		aLen := len(compA.value) - i
+		if aLen != len(compB.value)-j {
+			// Lengths differ; compare by length
+			return int32(aLen - (len(compB.value) - j))
+		}
+		// Compare by digits
+		for ; i < aLen; i, j = i+1, j+1 {
+			if compA.value[i] != compB.value[j] {
+				// Converting to digits is unnecessary (we're subtracting anyway)
+				return compA.value[i] - compB.value[j]
+			}
+		}
+	}
+	// One or both are null
+	if compA.t == componentTypeNull {
+		if compB.t == componentTypePreRelease {
+			return 1
+		}
+		return -1
+	} else if compB.t == componentTypeNull {
+		if compA.t == componentTypePreRelease {
+			return -1
+		}
+		return 1
+	}
+	// Textual comparison (differing type, or both textual/pre-release)
+	minLen := len(compA.value)
+	if len(compB.value) < minLen {
+		minLen = len(compB.value)
+	}
+	for i := 0; i < minLen; i++ {
+		a := compA.value[i]
+		b := compB.value[i]
+		if a != b {
+			// Compare by rune
+			return a - b
+		}
+	}
+	// Compare by length
+	return int32(len(compA.value) - len(compB.value))
+}
+
+// ErrInvalidUTF8 is returned from the *Error functions when a passed string is invalid UTF-8.
+var ErrInvalidUTF8 = errors.New("version string is invalid utf-8")
+
+func isASCIIDigit(r rune) bool {
+	return r >= '0' && r <= '9'
+}
+
+func decompose(str string) ([]component, error) {
+	var out []component
+	i := 0 // (byte index; not same as codepoint index!)
+	for i < len(str) {
+		var cur []rune
+		t := componentTypeTextual
+
+		if str[i] == '+' {
+			break // Ignore appendices
+		} else if str[i] == '-' && len(str) > i+1 {
+			// Mark as pre-release, eat first codepoint
+			t = componentTypePreRelease
+			i++
+		} else if isASCIIDigit(rune(str[i])) {
+			// Mark as numeric
+			t = componentTypeNumeric
+		}
+		for i < len(str) {
+			// Read a rune from the string
+			r, s := utf8.DecodeRuneInString(str[i:])
+			if r == utf8.RuneError {
+				return out, ErrInvalidUTF8
+			}
+			if isASCIIDigit(r) {
+				if t != componentTypeNumeric {
+					// Run completed (do not consume this digit)
+					break
+				}
+			} else if t == componentTypeNumeric {
+				// Run completed (do not consume this non-digit)
+				break
+			}
+			// Add rune to current run
+			cur = append(cur, r)
+			// Rune consumed; advance byte index by codepoint size
+			i += s
+		}
+
+		// Output component, if not empty
+		if len(cur) > 0 {
+			out = append(out, component{t: t, value: cur})
+		}
+	}
+	return out, nil
+}
+
+// CompareError compares two version numbers according to the FlexVer specification.
+// Returns a negative integer, 0 or a positive integer if version a is less than, equal to or greater than version b respectively.
+//
+// If either input version number is not valid UTF-8, [ErrInvalidUTF8] is returned.
+// See [Compare] for a variant of this function that panics instead of returning an error (more convenient if you know the strings are valid UTF-8).
+func CompareError(a, b string) (int32, error) {
+	// Decompose input strings, get length of the longest version
+	aDecomp, err := decompose(a)
+	if err != nil {
+		return 0, err
+	}
+	bDecomp, err := decompose(b)
+	if err != nil {
+		return 0, err
+	}
+	maxLen := len(aDecomp)
+	if len(bDecomp) > maxLen {
+		maxLen = len(bDecomp)
+	}
+
+	// Compare each component; using nullComponent if a string is exhausted
+	for i := 0; i < maxLen; i++ {
+		var res int32
+		if i >= len(aDecomp) {
+			res = nullComponent.compare(bDecomp[i])
+		} else if i >= len(bDecomp) {
+			res = aDecomp[i].compare(nullComponent)
+		} else {
+			res = aDecomp[i].compare(bDecomp[i])
+		}
+		if res != 0 {
+			return res, nil
+		}
+	}
+
+	return 0, nil
+}
+
+// Compare compares two version numbers according to the FlexVer specification.
+// Returns a negative integer, 0 or a positive integer if version a is less than, equal to or greater than version b respectively.
+//
+// If either input version number is not valid UTF-8, this function panics.
+// See [CompareError] for a variant of this function that returns an error instead of panicking.
+func Compare(a, b string) int32 {
+	r, err := CompareError(a, b)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+// Less compares two version numbers according to the FlexVer specification.
+// Returns true if version a is less than version b; useful for sorting functions in [sort] and [golang.org/x/exp/slices].
+//
+// If either input version number is not valid UTF-8, this function panics.
+// See [LessError] for a variant of this function that returns an error instead of panicking.
+func Less(a, b string) bool {
+	return Compare(a, b) < 0
+}
+
+// LessError compares two version numbers according to the FlexVer specification.
+// Returns true if version a is less than version b; useful for sorting functions in [sort] and [golang.org/x/exp/slices].
+//
+// If either input version number is not valid UTF-8, [ErrInvalidUTF8] is returned.
+// See [Less] for a variant of this function that panics instead of returning an error (more convenient if you know the strings are valid UTF-8).
+func LessError(a, b string) (bool, error) {
+	r, err := CompareError(a, b)
+	if err != nil {
+		return false, err
+	}
+	return r < 0, nil
+}
+
+// Equal compares two version numbers according to the FlexVer specification.
+// Returns true if version a is semantically equal to version b (only differs in appendix).
+//
+// If either input version number is not valid UTF-8, this function panics.
+// See [Equal] for a variant of this function that returns an error instead of panicking.
+func Equal(a, b string) bool {
+	return Compare(a, b) == 0
+}
+
+// EqualError compares two version numbers according to the FlexVer specification.
+// Returns true if version a is semantically equal to version b (only differs in appendix).
+//
+// If either input version number is not valid UTF-8, [ErrInvalidUTF8] is returned.
+// See [EqualError] for a variant of this function that panics instead of returning an error (more convenient if you know the strings are valid UTF-8).
+func EqualError(a, b string) (bool, error) {
+	r, err := CompareError(a, b)
+	if err != nil {
+		return false, err
+	}
+	return r == 0, nil
+}
+
+// VersionSlice implements [sort.Interface] as a type alias for a slice of version strings, to sort according to the FlexVer specification.
+// This can be obtained from an existing []string slice using a type conversion:
+//
+//	VersionSlice([]string{"1.0.0", "1.0.1"})
+//
+// This allows in-place sorting of a []string slice, as follows:
+//
+//	VersionSlice(vers).Sort()
+//
+// This implementation will panic if invalid UTF-8 strings are encountered.
+type VersionSlice []string
+
+func (s VersionSlice) Len() int           { return len(s) }
+func (s VersionSlice) Less(i, j int) bool { return Less(s[i], s[j]) }
+func (s VersionSlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+// Sort is a convenience method which calls [sort.Sort] on this slice.
+func (s VersionSlice) Sort() {
+	sort.Sort(s)
+}

--- a/go/flexver/main_test.go
+++ b/go/flexver/main_test.go
@@ -1,0 +1,238 @@
+/*
+ * To the extent possible under law, the author has dedicated all copyright
+ * and related and neighboring rights to this software to the public domain
+ * worldwide. This software is distributed without any warranty.
+ *
+ * See <http://creativecommons.org/publicdomain/zero/1.0/>
+ */
+
+package flexver
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestBasicSort(t *testing.T) {
+	var input = []string{
+		"0.17.2", "0.1.0", "1.0.0", "1000", "0.17.2-pre.1", "1.16.5+pre",
+	}
+	var expect = []string{
+		"0.1.0", "0.17.2-pre.1", "0.17.2", "1.0.0", "1.16.5+pre", "1000",
+	}
+	VersionSlice(input).Sort()
+	if !reflect.DeepEqual(input, expect) {
+		t.Fatalf("Failed to sort strings: got %v (expected %v)", input, expect)
+	}
+}
+
+const (
+	opLT        = -1
+	opEQ        = 0
+	opGT        = 1
+	shouldError = 10
+)
+
+func opChar(op int) string {
+	if op < 0 {
+		return "<"
+	} else if op == opEQ {
+		return "="
+	} else if op == opGT {
+		return ">"
+	} else {
+		return "!"
+	}
+}
+
+type testInstance struct {
+	a  string
+	op int
+	b  string
+}
+
+func t(a string, op int, b string) testInstance {
+	return testInstance{a: a, op: op, b: b}
+}
+
+func (i testInstance) name() string {
+	a := i.a
+	b := i.b
+	if !utf8.ValidString(a) {
+		a = "badutf8"
+	}
+	if !utf8.ValidString(b) {
+		b = "badutf8"
+	}
+	return a + " " + opChar(i.op) + " " + b
+}
+
+var specTests = []testInstance{
+	t("b1.7.3", opGT, "a1.2.6"),
+	t("a1.1.2", opLT, "a1.1.2_01"),
+	t("1.16.5-0.00.5", opGT, "1.14.2-1.3.7"),
+	t("1.0.0", opLT, "1.0.0_01"),
+	t("1.0.1", opGT, "1.0.0_01"),
+	t("0.17.1-beta.1", opLT, "0.17.1"),
+	t("0.17.1-beta.1", opLT, "0.17.1-beta.2"),
+	t("1.4.5_01", opEQ, "1.4.5_01+exp-1.17"),
+	t("1.4.5_01", opEQ, "1.4.5_01+exp-1.17-moretext"),
+	t("14w16a", opLT, "18w40b"),
+	t("18w40a", opLT, "18w40b"),
+	t("1.4.5_01+exp-1.17", opLT, "18w40b"),
+	t("13w02a", opLT, "c0.3.0_01"),
+	t("0.6.0-1.18.x", opLT, "0.9.beta-1.18.x"),
+	t("36893488147419103232", opLT, "36893488147419103233"),
+	t("1.0", opLT, "1.1"),
+	t("1.0", opLT, "1.0.1"),
+	t("10", opGT, "2"),
+}
+
+var coverageTests = []testInstance{
+	// Empty strings
+	t("", opEQ, ""),
+	t("1", opGT, ""),
+	t("", opLT, "1"),
+	// Invalid UTF8
+	t("\xc3\x28", shouldError, ""),
+	t("", shouldError, "\xc3\x28"),
+}
+
+var allTests = append(append([]testInstance{}, specTests...), coverageTests...)
+
+func TestCompare(t *testing.T) {
+	for _, v := range allTests {
+		t.Run(v.name(), func(t *testing.T) {
+			if v.op == shouldError {
+				// Catch panic
+				defer func() { _ = recover() }()
+			}
+
+			res := Compare(v.a, v.b)
+			if (v.op == opLT && res >= 0) ||
+				(v.op == opEQ && res != 0) ||
+				(v.op == opGT && res <= 0) ||
+				(v.op == shouldError) {
+				t.Fatalf("Unexpected result %v", res)
+			}
+		})
+	}
+}
+
+func TestLess(t *testing.T) {
+	for _, v := range allTests {
+		t.Run(v.name(), func(t *testing.T) {
+			if v.op == shouldError {
+				// Catch panic
+				defer func() { _ = recover() }()
+			}
+
+			res := Less(v.a, v.b)
+			if (v.op == opLT && res == false) ||
+				(v.op == opEQ && res == true) ||
+				(v.op == opGT && res == true) ||
+				(v.op == shouldError) {
+				t.Fatalf("Unexpected result %v", res)
+			}
+		})
+	}
+}
+
+func TestEqual(t *testing.T) {
+	for _, v := range allTests {
+		t.Run(v.name(), func(t *testing.T) {
+			if v.op == shouldError {
+				// Catch panic
+				defer func() { _ = recover() }()
+			}
+
+			res := Equal(v.a, v.b)
+			if (v.op == opLT && res == true) ||
+				(v.op == opEQ && res == false) ||
+				(v.op == opGT && res == true) ||
+				(v.op == shouldError) {
+				t.Fatalf("Unexpected result %v", res)
+			}
+		})
+	}
+}
+
+func TestCompareError(t *testing.T) {
+	for _, v := range allTests {
+		t.Run(v.name(), func(t *testing.T) {
+			res, err := CompareError(v.a, v.b)
+			if err == nil {
+				if (v.op == opLT && res >= 0) ||
+					(v.op == opEQ && res != 0) ||
+					(v.op == opGT && res <= 0) ||
+					(v.op == shouldError) {
+					t.Fatalf("Unexpected result %v", res)
+				}
+			} else if v.op != shouldError {
+				t.Fatalf("Unexpected error %v", err)
+			}
+		})
+	}
+}
+
+func TestLessError(t *testing.T) {
+	for _, v := range allTests {
+		t.Run(v.name(), func(t *testing.T) {
+			res, err := LessError(v.a, v.b)
+			if err == nil {
+				if (v.op == opLT && res == false) ||
+					(v.op == opEQ && res == true) ||
+					(v.op == opGT && res == true) ||
+					(v.op == shouldError) {
+					t.Fatalf("Unexpected result %v", res)
+				}
+			} else if v.op != shouldError {
+				t.Fatalf("Unexpected error %v", err)
+			}
+		})
+	}
+}
+
+func TestEqualError(t *testing.T) {
+	for _, v := range allTests {
+		t.Run(v.name(), func(t *testing.T) {
+			res, err := EqualError(v.a, v.b)
+			if err == nil {
+				if (v.op == opLT && res == true) ||
+					(v.op == opEQ && res == false) ||
+					(v.op == opGT && res == true) ||
+					(v.op == shouldError) {
+					t.Fatalf("Unexpected result %v", res)
+				}
+			} else if v.op != shouldError {
+				t.Fatalf("Unexpected error %v", err)
+			}
+		})
+	}
+}
+
+func ExampleCompare() {
+	fmt.Println(Compare("1.0.0", "1.0.1"), Compare("10.0.0", "1.0.1"))
+	// Output: -1 1
+}
+
+func ExampleLess() {
+	fmt.Println(Less("10.0.0", "1.0.1"), Less("10.0.0", "10.1.0.2"))
+	// Output: false true
+}
+
+func ExampleEqual() {
+	fmt.Println(Equal("1.0.0+fluffy", "1.0.0"), Equal("1.0.0", "1.0.0-pre.1"))
+	// Output: true false
+}
+
+func ExampleVersionSlice_Sort() {
+	// Type alias, works identically to []string
+	versions := VersionSlice{"100", "1.0.2", "0.1.2", "0.3.4-pre"}
+	// or VersionSlice([]string{ ... })
+	versions.Sort()
+	fmt.Println(versions)
+	// Output: [0.1.2 0.3.4-pre 1.0.2 100]
+}

--- a/go/flexver/main_test.go
+++ b/go/flexver/main_test.go
@@ -214,8 +214,8 @@ func TestEqualError(t *testing.T) {
 }
 
 func ExampleCompare() {
-	fmt.Println(Compare("1.0.0", "1.0.1"), Compare("10.0.0", "1.0.1"))
-	// Output: -1 1
+	fmt.Println(Compare("1.0.1", "1.0.3"), Compare("10.0.0", "1.0.1"))
+	// Output: -2 1
 }
 
 func ExampleLess() {

--- a/go/flexver/main_test.go
+++ b/go/flexver/main_test.go
@@ -90,7 +90,7 @@ var specTests = []testInstance{
 	t("10", opGT, "2"),
 }
 
-var coverageTests = []testInstance{
+var miscTests = []testInstance{
 	// Empty strings
 	t("", opEQ, ""),
 	t("1", opGT, ""),
@@ -98,9 +98,21 @@ var coverageTests = []testInstance{
 	// Invalid UTF8
 	t("\xc3\x28", shouldError, ""),
 	t("", shouldError, "\xc3\x28"),
+	// Check boundary between textual and prerelease
+	t("a-a", opLT, "a"),
+	// Check boundary between textual and appendix
+	t("a+a", opEQ, "a"),
+	// Dash is included in prerelease comparison (if stripped it will be a smaller component)
+	// Note that a-a < a=a regardless since the prerelease splits the component creating a smaller first component; 0 is added to force splitting regardless
+	t("a0-a", opLT, "a0=a"),
+	// Pre-releases must contain only non-digit
+	t("1.16.5-10", opGT, "1.16.5"),
+	// Pre-releases can have multiple dashes (should not be split)
+	// Reasoning for test data: "p-a!" > "p-a-" (correct); "p-a!" < "p-a t-" (what happens if every dash creates a new component)
+	t("-a-", opGT, "-a!"),
 }
 
-var allTests = append(append([]testInstance{}, specTests...), coverageTests...)
+var allTests = append(append([]testInstance{}, specTests...), miscTests...)
 
 func TestCompare(t *testing.T) {
 	for _, v := range allTests {


### PR DESCRIPTION
This PR contributes a Go implementation of FlexVer. Thank you for creating it, I enjoyed writing the implementation; the spec is very clear :) Personally I can see it being particularly useful for Modrinth version number comparison, where my current approach (try to parse as semver, fallback to release timestamp) is somewhat flaky.

I have a few things to mention:

- I'm curious about why `digit(codepoint)` is specified (and used in the Java impl) for codepoint-wise numeric comparison; is it just for better clarity?
  - The codepoints are subtracted so the constant offset doesn't matter (but I can add it to this impl if you like) 
- The package is in a subfolder (called flexver), since Go makes the last directory name the package name used by default in imports (so that calling code can use it as `flexver.Compare`)
- Go's module system uses Git repositories, so it can pull from this repo directly; however it requires Git tags to know the version of the module
  - Since the module is in a subdirectory, the tags would follow the format `go/flexver/v1.0.0` ([see these docs](https://go.dev/ref/mod#vcs-version))
  - If there are no tags in the correct format, it will still work; it just generates a pseudo-version number (e.g. `v0.0.0-20170915032832-14c0d48ead0c`)
  - It's up to you whether you want to create tags for releases of this implementation or not, I don't mind much regardless (but semver releases would be nicer!)