### PR TITLE
rust: remove nightly dependency and bump to 0.1.2

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.2
+- Cleaned up internals
+- Removed dependency on Nightly toolchain
 
 # 0.1.1
 - Numeric-to-text comparisons now match the spec (now that there *is* a spec)

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flexver-rs"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Infinidoge <infinidoge@inx.moe>"]
 description = "Comparer for FlexVer-spec versions"

--- a/rust/README.md
+++ b/rust/README.md
@@ -8,7 +8,7 @@ You can either copy (and rename) [lib.rs](src/lib.rs) wholesale into your projec
 
 ```toml
 [dependencies]
-flexver-rs = "0.1.0"
+flexver-rs = "0.1.2"
 ```
 
 ## Usage

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -6,11 +6,8 @@
  * See <http://creativecommons.org/publicdomain/zero/1.0/>
  */
 
-#![feature(pattern)]
-
 use std::cmp::Ordering::{self, Equal, Greater, Less};
 use std::collections::VecDeque;
-use std::str::pattern::Pattern;
 
 #[derive(Debug)]
 enum SortingType {
@@ -27,11 +24,12 @@ impl SortingType {
     }
 }
 
-fn split_once_rest<'a, P>(s: &'a str, pat: P) -> Option<(&str, &str)>
-where
-    P: Pattern<'a>,
-{
-    let loc = s.find(pat);
+fn split_once_rest<'a>(s: &'a str, numeric: bool) -> Option<(&str, &str)> {
+    let loc = s.find(if numeric {
+        |c: char| c.is_ascii_digit()
+    } else {
+        |c: char| !c.is_ascii_digit()
+    });
     if let Some(index) = loc {
         Some(s.split_at(index))
     } else {
@@ -58,7 +56,7 @@ fn decompose(str_in: &str) -> VecDeque<SortingType> {
 
     while !s.is_empty() {
         if last_numeric {
-            if let Some((left, right)) = split_once_rest(&s, |c: char| !c.is_ascii_digit()) {
+            if let Some((left, right)) = split_once_rest(&s, false) {
                 out.push_back(SortingType::Numerical(
                     left.parse::<i64>().unwrap(),
                     left.to_owned(),
@@ -66,7 +64,7 @@ fn decompose(str_in: &str) -> VecDeque<SortingType> {
                 s = right.to_owned();
                 last_numeric = false;
             }
-        } else if let Some((left, right)) = split_once_rest(&s, |c: char| c.is_ascii_digit()) {
+        } else if let Some((left, right)) = split_once_rest(&s, true) {
             out.push_back(if is_semver_prerelease(left) {
                 SortingType::SemverPrerelease(left.to_string())
             } else {


### PR DESCRIPTION
As per the title, refactored to not depend on the nightly `Pattern` feature.
Also accordingly bumped the version and updated the changelog/readme.
(Preferably kept as 2 separate commits)