### PR TITLE
Crystal implementation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@
 /js/ @unascribed
 /d/ @Moth-Tolias
 /go/ @comp500
+/crystal/ @oatmealine

--- a/crystal/.editorconfig
+++ b/crystal/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.cr]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/crystal/.gitignore
+++ b/crystal/.gitignore
@@ -1,0 +1,9 @@
+/docs/
+/lib/
+/bin/
+/.shards/
+*.dwarf
+
+# Libraries don't need dependency lock
+# Dependencies will be locked in applications that use them
+/shard.lock

--- a/crystal/README.md
+++ b/crystal/README.md
@@ -1,0 +1,37 @@
+# flexver
+
+A Crystal implementation of [FlexVer](https://github.com/unascribed/FlexVer).
+
+## Installation
+
+Due to the structure of [Shards dependencies](https://github.com/crystal-lang/shards/blob/master/docs/shard.yml.adoc#dependency-attributes)
+and the FlexVer repository, it's currently impossible to natively use `flexver` as a GitHub dependency in a `shard.yml`.
+However, you may instead use submodules:
+
+1. Add the repository as a submodule:
+    ```sh
+    git submodule add https://github.com/unascribed/FlexVer flexver
+    ```
+2. Use a local path for `shards.yml`:
+   ```yaml
+   dependencies:
+     flexver:
+      path: ./flexver/crystal
+   ```
+3. Run `shards install`.
+
+In the event that you need to update, run `git submodule update flexver`.
+
+## Usage
+
+```crystal
+require "flexver"
+
+FlexVer.new "b1.7.3" > FlexVer.new "a1.2.6" # => true
+FlexVer.new "0.17.1-beta.1" > FlexVer.new "0.17.1-beta.2" # => false
+# ...
+```
+
+## Contributors
+
+- [Jill "oatmealine" Monoids](https://github.com/your-github-user) - creator and maintainer

--- a/crystal/README.md
+++ b/crystal/README.md
@@ -4,28 +4,19 @@ A Crystal implementation of [FlexVer](https://github.com/unascribed/FlexVer).
 
 ## Installation
 
-Due to the structure of [Shards dependencies](https://github.com/crystal-lang/shards/blob/master/docs/shard.yml.adoc#dependency-attributes)
-and the FlexVer repository, it's currently impossible to natively use `flexver` as a GitHub dependency in a `shard.yml`.
-However, you may instead use submodules:
-
-1. Add the repository as a submodule:
-    ```sh
-    git submodule add https://github.com/unascribed/FlexVer flexver
-    ```
-2. Use a local path for `shards.yml`:
+1. Update your `shards.yml`:
    ```yaml
    dependencies:
      flexver:
-      path: ./flexver/crystal
+       github: unascribed/FlexVer
+       version: 0.1.0
    ```
-3. Run `shards install`.
-
-In the event that you need to update, run `git submodule update flexver`.
+2. Run `shards install`.
 
 ## Usage
 
 ```crystal
-require "flexver"
+require "flexver/crystal/src/flexver.cr"
 
 FlexVer.new "b1.7.3" > FlexVer.new "a1.2.6" # => true
 FlexVer.new "0.17.1-beta.1" > FlexVer.new "0.17.1-beta.2" # => false
@@ -34,4 +25,4 @@ FlexVer.new "0.17.1-beta.1" > FlexVer.new "0.17.1-beta.2" # => false
 
 ## Contributors
 
-- [Jill "oatmealine" Monoids](https://github.com/your-github-user) - creator and maintainer
+- [Jill "oatmealine" Monoids](https://github.com/oatmealine) - creator and maintainer

--- a/crystal/shard.yml
+++ b/crystal/shard.yml
@@ -1,0 +1,11 @@
+name: flexver
+description: A Crystal implementation of FlexVer
+repository: "https://github.com/unascribed/FlexVer"
+version: 0.1.0
+
+authors:
+  - Jill "oatmealine" Monoids <oatmealine@disroot.org>
+
+crystal: >= 1.6.2, < 2
+
+license: CC0-1.0

--- a/crystal/spec/flexver_spec.cr
+++ b/crystal/spec/flexver_spec.cr
@@ -1,0 +1,46 @@
+require "spec"
+require "../src/flexver.cr"
+
+describe FlexVer do
+  [
+    {"b1.7.3", '>', "a1.2.6"},
+    {"a1.1.2", '<', "a1.1.2_01"},
+    {"1.16.5-0.00.5", '>', "1.14.2-1.3.7"},
+    {"1.0.0", '<', "1.0.0_01"},
+    {"1.0.1", '>', "1.0.0_01"},
+    {"0.17.1-beta.1", '<', "0.17.1"},
+    {"0.17.1-beta.1", '<', "0.17.1-beta.2"},
+    {"1.4.5_01", '=', "1.4.5_01+exp-1.17"},
+    {"1.4.5_01", '=', "1.4.5_01+exp-1.17-moretext"},
+    {"14w16a", '<', "18w40b"},
+    {"18w40a", '<', "18w40b"},
+    {"0.6.0-1.18.x", '<', "0.9.beta-1.18.x"},
+    {"1.0", '<', "1.1"},
+    {"1.0", '<', "1.0.1"},
+    {"10", '>', "2"},
+
+    # codepoint-wise numeric comparasion check
+    {"36893488147419103232", '<', "36893488147419103233"},
+
+    # nonsense comparasions
+    {"1.4.5_01+exp-1.17", '<', "18w40b"},
+    {"13w02a", '<', "c0.3.0_01"},
+  ].each do |a, cmp, b|
+    it "performs sample comparasions correctly: #{a} #{cmp} #{b}" do
+      cmp_int = case cmp
+                when '>'
+                  1
+                when '<'
+                  -1
+                when '='
+                  0
+                end
+      (FlexVer.new(a) <=> FlexVer.new(b)).clamp(-1 .. 1).should eq(cmp_int)
+    end
+  end
+
+  it "handles re-composition correctly" do
+    ver = FlexVer.new "0.17.1-beta.1"
+    ver.to_s.should eq("0.17.1-beta.1")
+  end
+end

--- a/crystal/spec/flexver_spec.cr
+++ b/crystal/spec/flexver_spec.cr
@@ -1,31 +1,24 @@
 require "spec"
 require "../src/flexver.cr"
 
+private def parse_test(path : Path) : Array(Tuple(String, Char, String))
+  File.read(path)
+    .split("\n")
+    .reject(&.starts_with?("#"))
+    .reject(&.blank?)
+    .map do |line|
+      words = line.split(" ")
+      {words[0], words[1][0], words[2]}
+    end
+end
+
+TEST_DIR = Path.new("../test")
+TESTS = ["test_vectors.txt", "large.txt"]
+
 describe FlexVer do
-  [
-    {"b1.7.3", '>', "a1.2.6"},
-    {"a1.1.2", '<', "a1.1.2_01"},
-    {"1.16.5-0.00.5", '>', "1.14.2-1.3.7"},
-    {"1.0.0", '<', "1.0.0_01"},
-    {"1.0.1", '>', "1.0.0_01"},
-    {"0.17.1-beta.1", '<', "0.17.1"},
-    {"0.17.1-beta.1", '<', "0.17.1-beta.2"},
-    {"1.4.5_01", '=', "1.4.5_01+exp-1.17"},
-    {"1.4.5_01", '=', "1.4.5_01+exp-1.17-moretext"},
-    {"14w16a", '<', "18w40b"},
-    {"18w40a", '<', "18w40b"},
-    {"0.6.0-1.18.x", '<', "0.9.beta-1.18.x"},
-    {"1.0", '<', "1.1"},
-    {"1.0", '<', "1.0.1"},
-    {"10", '>', "2"},
+  tests = TESTS.map { |file| parse_test(TEST_DIR / file) } .sum
 
-    # codepoint-wise numeric comparasion check
-    {"36893488147419103232", '<', "36893488147419103233"},
-
-    # nonsense comparasions
-    {"1.4.5_01+exp-1.17", '<', "18w40b"},
-    {"13w02a", '<', "c0.3.0_01"},
-  ].each do |a, cmp, b|
+  tests.each do |a, cmp, b|
     it "performs sample comparasions correctly: #{a} #{cmp} #{b}" do
       cmp_int = case cmp
                 when '>'

--- a/crystal/src/flexver.cr
+++ b/crystal/src/flexver.cr
@@ -1,0 +1,149 @@
+# Reimplementing this because the Crystal standard
+# library `compare` method does not account for UTF-8
+private def compare(a : String, b : String) : Int32
+  a.chars <=> b.chars
+end
+
+# Conforms to FlexVer 1.0.1_09
+#
+# See: [https://github.com/unascribed/FlexVer/](https://github.com/unascribed/FlexVer/)
+#
+# Differs quite greatly from the standard library's `SemanticVersion` as there
+# is no single way to represent a FlexVer - only a `parse`-type method is
+# implemented as the initializer (see: `new`).
+#
+# ```
+# FlexVer.new "b1.7.3" > FlexVer.new "a1.2.6" # => true
+# FlexVer.new "0.17.1-beta.1" > FlexVer.new "0.17.1-beta.2" # => false
+# # ...
+# ```
+struct FlexVer
+  include Comparable(self)
+
+  getter components : Array(Component)
+
+  private enum ComponentType
+    # The run is entirely non-digit codepoints
+    Textual
+    # The run is entirely digit codepoints
+    Numeric
+    # The run's first codepoint is ASCII hyphen-minus (`-`) **and is longer than one codepoint**
+    PreRelease
+    # The run's first codepoint is ASCII plus (`+`)
+    Appendix
+    # Represents blank padding spots used when two versions' lengths do not match.
+    Null
+  end
+
+  # Represents a [component](https://github.com/unascribed/FlexVer/blob/trunk/SPEC.md#decomposition)
+  # after decomposition; see `ComponentType`.
+  private struct Component
+    include Comparable(self)
+
+    getter str : String
+    getter type : ComponentType
+
+    # Initializing with an empty string (done so by default) will return
+    # a component of type `ComponentType::Null`.
+    def initialize(@str : String = "")
+      case @str[0]?
+      when Nil
+        @type = ComponentType::Null
+      when .ascii_number?
+        @type = ComponentType::Numeric
+      when '-', @str.size > 1
+        @type = ComponentType::PreRelease
+      when '+'
+        @type = ComponentType::Appendix
+      else
+        @type = ComponentType::Textual
+      end
+    end
+
+    # The comparison operator.
+    #
+    # Returns `-1`, `0` or `1` depending on whether `self` is considered lower than _other_'s, equal to _other_'s version or greater than _other_.
+    #
+    # See: [https://github.com/unascribed/FlexVer/blob/trunk/SPEC.md#comparison](https://github.com/unascribed/FlexVer/blob/trunk/SPEC.md#comparison)
+    def <=>(other : self) : Int32
+      # Done the ugly way because of a Crystal bug?
+      #
+      # when value
+      # case true
+      #   # this code never runs!
+      # end
+      #
+      # This prevents us from using `case ... in`, hence the ugly `else` case at the end
+
+      case
+      when type == ComponentType::Null
+        other.type == ComponentType::PreRelease ? 1 : -1
+      when type == ComponentType::PreRelease && other.type == ComponentType::Null
+        -1
+      when type == ComponentType::Textual, type == ComponentType::PreRelease, type != other.type
+        # Textual comparasion
+        str.chars <=> other.str.chars
+      when type == ComponentType::Numeric
+        # Numeric comparasion
+        # Implemented as described under "Codepoint-wise"
+        if str.size != other.str.size
+          return str.size <=> other.str.size end
+        str.lstrip('0').chars <=> other.str.lstrip('0').chars
+      else
+        raise "#{type} ? #{other.type}"
+      end
+    end
+
+    def to_s(io : IO) : Nil
+      io << str
+    end
+  end
+
+  # Parses `version_str` and creates a version object.
+  def initialize(version_str : String)
+    chunked = version_str.chars.chunks &.ascii_number?
+    components = chunked.map { |_, v| Component.new(v.join) }
+    @components = components.take_while { |c| c.type != ComponentType::Appendix }
+  end
+
+  # The comparison operator.
+  #
+  # Returns `-1`, `0` or `1` depending on whether `self`'s version is lower than _other_'s, equal to _other_'s version or greater than _other_'s version.
+  #
+  # ```
+  # ver1 = FlexVer.new "b1.7.3"
+  # ver2 = FlexVer.new "a1.2.6"
+  #
+  # ver1 <=> ver2 # => 1
+  # ver1 <=> ver1 # => 0
+  # ver2 <=> ver1 # => -1
+  # ```
+  def <=>(other : self) : Int32
+    (0 .. (Math.max(components.size, other.components.size) - 1)).each do |i|
+      a = components[i]?
+      b = other.components[i]?
+
+      # default to nulls
+      c = (a || Component.new) <=> (b || Component.new)
+
+      if c != 0
+        return c end
+    end
+    components <=> other.components
+  end
+
+  # Returns the string representation of this version
+  #
+  # NOTE: This will get rid of appendices (`+foo`), so it is not guaranteed
+  # to be the exact same string passed into `new`.
+  #
+  # ```
+  # ver = FlexVer.new "0.17.1-beta.1"
+  # ver.to_s # => "0.17.1-beta.1"
+  # ```
+  def to_s(io : IO) : Nil
+    components.each do |component|
+      component.to_s(io)
+    end
+  end
+end

--- a/shard.yml
+++ b/shard.yml
@@ -3,6 +3,10 @@ description: A Crystal implementation of FlexVer
 repository: "https://github.com/unascribed/FlexVer"
 version: 0.1.0
 
+targets:
+  flexver:
+    main: crystal/src/flexver.cr
+
 authors:
   - Jill "oatmealine" Monoids <oatmealine@disroot.org>
 

--- a/shard.yml
+++ b/shard.yml
@@ -10,6 +10,6 @@ targets:
 authors:
   - Jill "oatmealine" Monoids <oatmealine@disroot.org>
 
-crystal: >= 1.6.2, < 2
+crystal: ">= 1.6.2, < 2"
 
 license: CC0-1.0


### PR DESCRIPTION
This is _almost_ ready for use, however, there are two issues I want to sort out:

1. How would documentation be done? Typically, with Crystal shards, you would run `crystal book` and view `docs/` in your favorite browser, however this is typically automated via CI (typically GitHub Actions and GitHub Pages, see [here](https://github.com/oatmealine/gd-icon-renderer/blob/main/.github/workflows/doc.yml) for an example). It might be more convenient to host it somewhere, even if manually; however, it's not a big deal, and the bigger issue is:
2. There is currently no way to _natively_ use this shard as a proper dependency in a `shards.yml`. Shards dependency management is typically done by pulling from Git URLs, however it does not have support for pulling from a specific folder, only the entire repository. This could possibly be addressed by moving the implementation into a separate branch, but that brings in a bunch of other issues (duplicated code across two branches? how to note in the in-repo README well? etc). Currently this is workaroundable by using Git submodules, but using Git submodules for dependency management is not ideal when there already is a package manager for Crystal.

It's for those two reasons that I wonder if maybe this implementation would be better off on a separate repository rather than in this repository. If those two issues aren't that big of a deal; great, merge and move on; but otherwise I'm willing to use a separate repository or whatever is more convenient.

- [x] I own the full rights to my contribution, and agree to release it under the terms of the Creative Commons Zero Public Domain Dedication