### PR TITLE
csharp: sync `v1.1.0` from John-Paul-R/FlexVer

### DIFF
--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -1,0 +1,18 @@
+<Project>
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <NoWarn>
+            <!-- non-exhaustive switch expression: Unnamed Enum Value (e.g. underlying type cast to enum).
+                Disabling to enable SwitchExpressionException.-->
+            CS8524,
+        </NoWarn>
+    </PropertyGroup>
+
+</Project>

--- a/csharp/Directory.Packages.props
+++ b/csharp/Directory.Packages.props
@@ -1,0 +1,13 @@
+<Project>
+    <ItemGroup>
+        <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageVersion Include="BenchmarkDotNet" Version="0.13.5" />
+
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageVersion Include="NUnit" Version="3.13.3" />
+        <PackageVersion Include="NUnit3TestAdapter" Version="4.4.2" />
+        <PackageVersion Include="NUnit.Analyzers" Version="3.6.1" />
+        <PackageVersion Include="coverlet.collector" Version="3.2.0" />
+
+    </ItemGroup>
+</Project>

--- a/csharp/FlexVer.sln
+++ b/csharp/FlexVer.sln
@@ -4,6 +4,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlexVer", "FlexVer\FlexVer.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlexVerTests", "FlexVerTests\FlexVerTests.csproj", "{6607097E-4D6F-491E-87AE-40BFDF6C858A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlexVerBenchmarkHarness", "FlexVerBenchmarkHarness\FlexVerBenchmarkHarness.csproj", "{6F8DC208-6EA3-4341-B602-C3477FC90F22}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{6607097E-4D6F-491E-87AE-40BFDF6C858A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6607097E-4D6F-491E-87AE-40BFDF6C858A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6607097E-4D6F-491E-87AE-40BFDF6C858A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F8DC208-6EA3-4341-B602-C3477FC90F22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F8DC208-6EA3-4341-B602-C3477FC90F22}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F8DC208-6EA3-4341-B602-C3477FC90F22}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F8DC208-6EA3-4341-B602-C3477FC90F22}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/csharp/FlexVer.sln.DotSettings
+++ b/csharp/FlexVer.sln.DotSettings
@@ -1,2 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_STYLE/@EntryValue">Tab</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_STYLE/@EntryValue">Tab</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/csharp/FlexVer/FlexVer.csproj
+++ b/csharp/FlexVer/FlexVer.csproj
@@ -4,6 +4,8 @@
         <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+
+        <NuspecFile>FlexVer.nuspec</NuspecFile>
     </PropertyGroup>
 
 </Project>

--- a/csharp/FlexVer/FlexVer.csproj
+++ b/csharp/FlexVer/FlexVer.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-
         <NuspecFile>FlexVer.nuspec</NuspecFile>
     </PropertyGroup>
 

--- a/csharp/FlexVer/FlexVer.nuspec
+++ b/csharp/FlexVer/FlexVer.nuspec
@@ -3,7 +3,7 @@
     <metadata>
         <!-- Required elements-->
         <id>FlexVer</id>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
         <description>
             A SemVer-compatible intuitive comparator for free-form versioning
             strings as seen in the wild, designed to sort versions like people

--- a/csharp/FlexVer/FlexVer.nuspec
+++ b/csharp/FlexVer/FlexVer.nuspec
@@ -3,7 +3,7 @@
     <metadata>
         <!-- Required elements-->
         <id>FlexVer</id>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <description>
             A SemVer-compatible intuitive comparator for free-form versioning
             strings as seen in the wild, designed to sort versions like people

--- a/csharp/FlexVer/FlexVer.nuspec
+++ b/csharp/FlexVer/FlexVer.nuspec
@@ -13,17 +13,19 @@
 
         <!-- Optional elements -->
         <projectUrl>https://github.com/unascribed/FlexVer/tree/trunk/csharp</projectUrl>
-        <license type="CC0-1.0"/>
-        <icon>icon.png</icon>
-        <readme>readme.md</readme>
+        <repository type="git" url="https://github.com/unascribed/FlexVer.git" branch="trunk" />
+        <projectUrl>https://github.com/unascribed/FlexVer/tree/trunk/csharp</projectUrl>
+        <license type="expression">CC0-1.0</license>
+        <icon>FlexVer-logo.png</icon>
+        <readme>README.md</readme>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <developmentDependency>false</developmentDependency>
-        <tags>Version Comparer</tags>
+        <tags>Version Comparer,SemVer,Version Sort,Version Order</tags>
         <!-- ... -->
     </metadata>
     <!-- Optional 'files' node -->
     <files>
-        <file src="icon.png" target="\" />
-        <file src="readme.md" target="\" />
+        <file src="../FlexVer-logo.png" target="\" />
+        <file src="./README.md" target="\" />
     </files>
 </package>

--- a/csharp/FlexVer/FlexVerComparer.cs
+++ b/csharp/FlexVer/FlexVerComparer.cs
@@ -185,7 +185,7 @@ public static class FlexVerComparer
 				break;
 			}
 
-			bool isNumber = Rune.IsDigit(cp);
+			bool isNumber = cp.IsAscii && Rune.IsDigit(cp);
 			if (// Ending a Number component
 				isNumber != lastWasNumber
 				// Starting a new PreRelease component

--- a/csharp/FlexVer/FlexVerComparer.cs
+++ b/csharp/FlexVer/FlexVerComparer.cs
@@ -95,9 +95,7 @@ public static class FlexVerComparer
 
 		public static int CompareTo(VersionComponent cur, VersionComponent other)
 		{
-#pragma warning disable CS8524
 			return cur.ComponentType switch
-#pragma warning restore CS8524
 			{
 				VersionComponentType.Default => CompareToBase(cur, other),
 				VersionComponentType.Null when other.ComponentType == VersionComponentType.Null => 0,

--- a/csharp/FlexVer/README.md
+++ b/csharp/FlexVer/README.md
@@ -1,0 +1,42 @@
+
+# FlexVer
+FlexVer is a SemVer-compatible intuitive comparator for free-form versioning strings as seen in the
+wild. It's designed to sort versions like people do, rather than attempting to force conformance to
+a rigid and limited standard. This repo collects meta information and discussion on FlexVer, as well
+as implementations of it in various languages. Notably, it houses a [specification](SPEC.md).
+
+It works by splitting a string into "numeric" and "non-numeric" parts, and then sorting those
+lexically, with a few special cases for SemVer compatibility. This mode of operation is similar to
+how `sort -V` behaves in GNU coreutils. As such, when used solely for simple comparisons and not
+group-aware things (such as ~ matches), it is also a stand-in for a SemVer parser (with one
+exception — read on)
+
+Below is a test harness used to verify the logic:
+
+![image](https://user-images.githubusercontent.com/6185037/200154644-b94b61bf-e430-4dbd-bd2e-caddab86c9f2.png)
+
+Cyan is numeric, pink is non-numeric, red is SemVer pre-releases, and gray is ignored SemVer-style
+appendices. As the potential problem space of version number comparisons is infinite, I cannot
+devise a good way to truly verify this is a completely sound implementation; so, I simply
+cherry-picked some random examples of versions that I felt would trip up a version comparator, which
+both do and do not follow SemVer. As such, there are no unit tests; I feel a system like this only
+benefits from regression tests, after basic sanity tests done during development.
+
+It is a non-goal for comparisons between versions of entirely different structures to "make sense" —
+but nonetheless, it does try its best and will normalize structural differences and fall back to
+lexical comparison when all else fails. Fundamentally, ***FlexVer does not impose any form of
+restrictions*** — it will always do its best to compare two strings and *never* throw an exception.
+If you do pass two completely different versions to it, well....
+
+![image](https://user-images.githubusercontent.com/6185037/200155199-a80a03cf-9820-4075-9763-efff800e2507.png)
+
+...the results won't necessarily make sense. Garbage in, garbage out.
+
+There is **one known case where FlexVer and SemVer disagree**. It is related to pre-releases, as
+they are an exception to the intuitive version flow. There is a special case that makes the most
+common forms of them work, such as `-pre1`, `-rc2`, `-beta.2`, etc. However, this works by looking
+for a non-numeric component that starts with `-` and is longer than one character. As such, if you
+have a pre-release starting with a numeral, then FlexVer's normal parsing kicks in, which sorts
+`1.0.0` and `1.0.0-2` *in the opposite order that SemVer would*. However, I have never seen fully
+numeric pre-releases like this in the wild; a hyphenated numeric like that is generally meant to
+represent another "group" of versions — in which case, FlexVer does indeed sort it as expected.

--- a/csharp/FlexVer/ValueListBuilder.cs
+++ b/csharp/FlexVer/ValueListBuilder.cs
@@ -1,0 +1,87 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace FlexVer;
+
+internal ref struct ValueListBuilder<T>
+{
+	private Span<T> _span;
+	private int _pos;
+
+	public static ValueListBuilder<T> Empty()
+		=> new ValueListBuilder<T>(Span<T>.Empty);
+
+	public ValueListBuilder(Span<T> initialSpan)
+	{
+		_span = initialSpan;
+		_pos = 0;
+	}
+
+	public int Length
+	{
+		get => _pos;
+		set
+		{
+			Debug.Assert(value >= 0);
+			Debug.Assert(value <= _span.Length);
+			_pos = value;
+		}
+	}
+
+	public int Capacity
+	{
+		get => _span.Length;
+	}
+
+	public ref T this[int index]
+	{
+		get
+		{
+			Debug.Assert(index < _pos);
+			return ref _span[index];
+		}
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Append(T item)
+	{
+		int pos = _pos;
+		if (pos >= _span.Length)
+			Grow();
+
+		_span[pos] = item;
+		_pos = pos + 1;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void AppendRange(T[] items)
+	{
+		int pos = _pos;
+		while (pos + items.Length >= _span.Length) {
+			Grow();
+		}
+
+
+		foreach (T item in items)
+		{
+			_span[pos] = item;
+			_pos = pos + 1;
+			pos++;
+		}
+	}
+
+	public ReadOnlySpan<T> AsSpan()
+	{
+		return _span[.._pos];
+	}
+
+	public void Grow()
+	{
+		T[] array = new T[_span.Length * 2];
+
+		bool success = _span.TryCopyTo(array);
+		Debug.Assert(success);
+
+		_span = array;
+	}
+}

--- a/csharp/FlexVerBenchmarkHarness/FlexVerBenchmarkHarness.csproj
+++ b/csharp/FlexVerBenchmarkHarness/FlexVerBenchmarkHarness.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\FlexVer\FlexVer.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/csharp/FlexVerBenchmarkHarness/FlexVerBenchmarkHarness.csproj
+++ b/csharp/FlexVerBenchmarkHarness/FlexVerBenchmarkHarness.csproj
@@ -14,4 +14,10 @@
         <ProjectReference Include="..\FlexVer\FlexVer.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <Content Include="..\..\test\*.*">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+
 </Project>

--- a/csharp/FlexVerBenchmarkHarness/FlexVerBenchmarkHarness.csproj
+++ b/csharp/FlexVerBenchmarkHarness/FlexVerBenchmarkHarness.csproj
@@ -2,17 +2,16 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+        <PackageReference Include="BenchmarkDotNet" />
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\FlexVer\FlexVer.csproj" />
+        <ProjectReference Include="..\FlexVer\FlexVer.csproj" />
     </ItemGroup>
 
 </Project>

--- a/csharp/FlexVerBenchmarkHarness/Program.cs
+++ b/csharp/FlexVerBenchmarkHarness/Program.cs
@@ -1,0 +1,102 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using FlexVer;
+
+BenchmarkRunner.Run<Benchmarker>();
+
+[MemoryDiagnoser]
+public class Benchmarker
+{
+	private List<(string, string)> _versionsToCompare = null!;
+
+	[Benchmark]
+	public void CompareAll_New()
+	{
+		foreach (var (a, b) in _versionsToCompare) {
+			// FlexVerComparerV2.Compare(a, b);
+		}
+	}
+
+	[Benchmark]
+	public void CompareAll_Existing()
+	{
+		foreach (var (a, b) in _versionsToCompare) {
+			FlexVerComparer.Compare(a, b);
+		}
+	}
+
+#region TestData
+	[GlobalSetup]
+	public void Setup()
+	{
+		_versionsToCompare = VersionsToTest.Split('\n')
+			.Where(line => !line.StartsWith('#'))
+			.Where(line => !string.IsNullOrWhiteSpace(line))
+			.Select(line =>
+			{
+				var split = line.Split(' ');
+				if (split.Length != 3) throw new ArgumentException($"Line formatted incorrectly, expected 2 spaces: '{line}'");
+				return (split[0], split[2]);
+			})
+			.ToList();
+	}
+
+	private const string VersionsToTest = """
+		# This test file is formatted as "<lefthand> <operator> <righthand>", seperated by the space character
+		# Implementations should ignore lines starting with "#" and lines that have a length of 0
+
+		# Basic numeric ordering (lexical string sort fails these)
+		10 > 2
+		100 > 10
+
+		# Trivial common numerics
+		1.0 < 1.1
+		1.0 < 1.0.1
+		1.1 > 1.0.1
+
+		# SemVer compatibility
+		1.5 > 1.5-pre1
+		1.5 = 1.5+foobar
+
+		# SemVer incompatibility
+		1.5 < 1.5-2
+		1.5-pre10 > 1.5-pre2
+
+		# Check boundary between textual and prerelease
+		a-a < a
+
+		# Check boundary between textual and appendix
+		a+a = a
+
+		# Dash is included in prerelease comparison (if stripped it will be a smaller component)
+		# Note that a-a < a=a regardless since the prerelease splits the component creating a smaller first component; 0 is added to force splitting regardless
+		a0-a < a0=a
+
+		# Pre-releases must contain only non-digit
+		1.16.5-10 > 1.16.5
+
+		# Pre-releases can have multiple dashes (should not be split)
+		# Reasoning for test data: "p-a!" > "p-a-" (correct); "p-a!" < "p-a t-" (what happens if every dash creates a new component)
+		-a- > -a!
+
+		# Misc
+		b1.7.3 > a1.2.6
+		b1.2.6 > a1.7.3
+		a1.1.2 < a1.1.2_01
+		1.16.5-0.00.5 > 1.14.2-1.3.7
+		1.0.0 < 1.0.0_01
+		1.0.1 > 1.0.0_01
+		1.0.0_01 < 1.0.1
+		0.17.1-beta.1 < 0.17.1
+		0.17.1-beta.1 < 0.17.1-beta.2
+		1.4.5_01 = 1.4.5_01+fabric-1.17
+		1.4.5_01 = 1.4.5_01+fabric-1.17+ohgod
+		14w16a < 18w40b
+		18w40a < 18w40b
+		1.4.5_01+fabric-1.17 < 18w40b
+		13w02a < c0.3.0_01
+		0.6.0-1.18.x < 0.9.beta-1.18.x
+		19283091283091283091283901283901289031289031283917280371230912730917290371290371209731209371209312.skfjslakdfjklasjdfklasjdklfjasdlkfjasdlkjflaskdjflkasdjflksadjfklasdjfklsadjfklasdjkfljsakldfjalskjdflas.akdaljskda > 1029301293019231.12312.21312312
+		""";
+#endregion TestData
+}

--- a/csharp/FlexVerBenchmarkHarness/Program.cs
+++ b/csharp/FlexVerBenchmarkHarness/Program.cs
@@ -10,14 +10,6 @@ public class Benchmarker
 	private List<(string, string)> _versionsToCompare = null!;
 
 	[Benchmark]
-	public void CompareAll_New()
-	{
-		foreach (var (a, b) in _versionsToCompare) {
-			// FlexVerComparerV2.Compare(a, b);
-		}
-	}
-
-	[Benchmark]
 	public void CompareAll_Existing()
 	{
 		foreach (var (a, b) in _versionsToCompare) {
@@ -29,7 +21,7 @@ public class Benchmarker
 	[GlobalSetup]
 	public void Setup()
 	{
-		_versionsToCompare = VersionsToTest.Split('\n')
+		_versionsToCompare = File.ReadAllLines("test_vectors.txt")
 			.Where(line => !line.StartsWith('#'))
 			.Where(line => !string.IsNullOrWhiteSpace(line))
 			.Select(line =>
@@ -40,63 +32,5 @@ public class Benchmarker
 			})
 			.ToList();
 	}
-
-	private const string VersionsToTest = """
-		# This test file is formatted as "<lefthand> <operator> <righthand>", seperated by the space character
-		# Implementations should ignore lines starting with "#" and lines that have a length of 0
-
-		# Basic numeric ordering (lexical string sort fails these)
-		10 > 2
-		100 > 10
-
-		# Trivial common numerics
-		1.0 < 1.1
-		1.0 < 1.0.1
-		1.1 > 1.0.1
-
-		# SemVer compatibility
-		1.5 > 1.5-pre1
-		1.5 = 1.5+foobar
-
-		# SemVer incompatibility
-		1.5 < 1.5-2
-		1.5-pre10 > 1.5-pre2
-
-		# Check boundary between textual and prerelease
-		a-a < a
-
-		# Check boundary between textual and appendix
-		a+a = a
-
-		# Dash is included in prerelease comparison (if stripped it will be a smaller component)
-		# Note that a-a < a=a regardless since the prerelease splits the component creating a smaller first component; 0 is added to force splitting regardless
-		a0-a < a0=a
-
-		# Pre-releases must contain only non-digit
-		1.16.5-10 > 1.16.5
-
-		# Pre-releases can have multiple dashes (should not be split)
-		# Reasoning for test data: "p-a!" > "p-a-" (correct); "p-a!" < "p-a t-" (what happens if every dash creates a new component)
-		-a- > -a!
-
-		# Misc
-		b1.7.3 > a1.2.6
-		b1.2.6 > a1.7.3
-		a1.1.2 < a1.1.2_01
-		1.16.5-0.00.5 > 1.14.2-1.3.7
-		1.0.0 < 1.0.0_01
-		1.0.1 > 1.0.0_01
-		1.0.0_01 < 1.0.1
-		0.17.1-beta.1 < 0.17.1
-		0.17.1-beta.1 < 0.17.1-beta.2
-		1.4.5_01 = 1.4.5_01+fabric-1.17
-		1.4.5_01 = 1.4.5_01+fabric-1.17+ohgod
-		14w16a < 18w40b
-		18w40a < 18w40b
-		1.4.5_01+fabric-1.17 < 18w40b
-		13w02a < c0.3.0_01
-		0.6.0-1.18.x < 0.9.beta-1.18.x
-		19283091283091283091283901283901289031289031283917280371230912730917290371290371209731209371209312.skfjslakdfjklasjdfklasjdklfjasdlkfjasdlkjflaskdjflkasdjflksadjfklasdjfklsadjfklasdjkfljsakldfjalskjdflas.akdaljskda > 1029301293019231.12312.21312312
-		""";
 #endregion TestData
 }

--- a/csharp/FlexVerTests/FlexVerBasicTest.cs
+++ b/csharp/FlexVerTests/FlexVerBasicTest.cs
@@ -34,6 +34,8 @@ public class Tests
 	[TestCase(null, "1.0.0", Ordering.Less)]
 	[TestCase("1.0.0", null, Ordering.Greater)]
 	[TestCase("1.0.0", "1.0.0", Ordering.Equal)]
+	// BUG: (likely) https://github.com/unascribed/FlexVer/issues/17
+	// [TestCase("0000.0.0", "0.0.0", Ordering.Equal)]
 	public void TestEquality_DefaultComparerInstance_HandlesClrNulls(string? a, string? b, Ordering expectedOrdering)
 	{
 		Ordering c = OrderingExtensions.FromComparison(FlexVerComparer.Default.Compare(a, b));

--- a/csharp/FlexVerTests/FlexVerTests.csproj
+++ b/csharp/FlexVerTests/FlexVerTests.csproj
@@ -1,20 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
-        <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
-        <PackageReference Include="coverlet.collector" Version="3.2.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="NUnit.Analyzers" />
+        <PackageReference Include="coverlet.collector" />
     </ItemGroup>
 
     <ItemGroup>

--- a/csharp/FlexVerTests/Ordering.cs
+++ b/csharp/FlexVerTests/Ordering.cs
@@ -1,6 +1,5 @@
 namespace FlexVerTests;
 
-#pragma warning disable CS8524 // Exhaustive switch (e.g. underlying type cast to enum). Disabling to enable SwitchExpressionException.
 
 public enum Ordering
 {


### PR DESCRIPTION

This PR deals with some build/packaging details, and reworks the comparer implementation to be faster and make no heap allocations.

Benchmark results, using the version strings in the test harness:

|              Method |      Mean |     Error |    StdDev |   Gen0 | Allocated |
|-------------------- |----------:|----------:|----------:|-------:|----------:|
|      CompareAll_New |  6.248 us | 0.1228 us | 0.2245 us |      - |         - |
| CompareAll_Existing | 30.432 us | 0.6077 us | 1.1112 us | 0.3967 |   33672 B |

NuGet listing from these build changes: https://www.nuget.org/packages/FlexVer

---

- [x] I own the full rights to my contribution, and agree to release it under the terms of the Creative Commons Zero Public Domain Dedication
